### PR TITLE
Moved the user agent directly into the source

### DIFF
--- a/src/PromClient.cpp
+++ b/src/PromClient.cpp
@@ -117,7 +117,7 @@ PromClient::SendResult PromClient::_send(uint8_t* entry, size_t len) {
         _httpClient->sendBasicAuth(_user, _pass);
     }
     _client->print("User-Agent: ");
-    _client->println(PromUserAgent);
+    _client->println("prom-arduino/0.2.2");
     _client->print("Content-Length: ");
     _client->println(len);
     _httpClient->beginBody();

--- a/src/PromClient.h
+++ b/src/PromClient.h
@@ -6,8 +6,6 @@
 #include <ArduinoHttpClient.h>
 #include "PromDebug.h"
 
-static const char PromUserAgent[] PROGMEM = "prom-arduino/0.2.2";
-
 class PromClient {
 public:
     PromClient();


### PR DESCRIPTION
For the ESP8266 target, having the character string in the PROGMEM was causing a runtime error. When combined with another change for the 'arduino-prom-loki-transport' to re-enable the ESP8266, the ability to push to a Prometheus server works correctly.