### PR TITLE
change URL to HOST for clarity

### DIFF
--- a/examples/prom_02_grafana_cloud/config.h
+++ b/examples/prom_02_grafana_cloud/config.h
@@ -2,7 +2,7 @@
 #define WIFI_PASSWORD ""
 
 // For more information on where to get these values see: https://github.com/grafana/diy-iot/blob/main/README.md#sending-metrics
-#define GC_URL "prometheus-blocks-prod-us-central1.grafana.net"
+#define GC_HOST "prometheus-blocks-prod-us-central1.grafana.net"
 #define GC_PATH "/api/prom/push"
 #define GC_PORT 443
 #define GC_USER ""

--- a/examples/prom_02_grafana_cloud/prom_02_grafana_cloud.ino
+++ b/examples/prom_02_grafana_cloud/prom_02_grafana_cloud.ino
@@ -59,7 +59,7 @@ void setup() {
     }
 
     // Configure the client
-    client.setUrl(GC_URL);
+    client.setUrl(GC_HOST);
     client.setPath((char*)GC_PATH);
     client.setPort(GC_PORT);
     client.setUser(GC_USER);


### PR DESCRIPTION
Extremely minor change to the GC example that changes 'URL' to 'HOST' when specifying the GC Prometheus instance.  (This bit me because I saw 'URL' and assumed it wanted the full URL here instead of the hostname.)